### PR TITLE
Port to winnow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,27 +109,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
-]
-
-[[package]]
 name = "obs-countdown"
 version = "0.1.0"
 dependencies = [
  "clap",
- "nom",
+ "winnow",
 ]
 
 [[package]]
@@ -244,3 +228,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+
+[[package]]
+name = "winnow"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8"
+dependencies = [
+ "memchr",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ readme = "README.md"
 
 [dependencies]
 clap = { version = "4.5.1", features = ["derive"] }
-nom = "7.1.3"
+winnow = "0.6.5"


### PR DESCRIPTION
winnow is a successor of `nom` which introduces many improvements.

More infos:
https://docs.rs/winnow/latest/winnow/_topic/why/index.html

I used `void` because most of the parsed values are not relevant. You don't need the string that is parsed. But it can be modified to remove `void`.